### PR TITLE
Conditionally modifying the query when using recordsOf method

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ use Freshbitsweb\Laratables\Laratables;
 ...
 return Laratables::recordsOf(User::class);
 ```
+Optionally, you can pass a closure as a second parameter to refine the query:
+```php
+use App\User;
+use Freshbitsweb\Laratables\Laratables;
+...
+return Laratables::recordsOf(User::class, function($query)
+{
+    return $query->where('active', true);
+});
+```
 
 ## Online Demo
 

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -41,7 +41,9 @@ class Laratables
         }
 
         $instance->applyFiltersTo();
+        
         $records = $instance->fetchRecords();
+        
         $records = $instance->recordsTransformer->transformRecords($records);
 
         return $instance->tableData($records);

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -36,8 +36,7 @@ class Laratables
     {
         if ($model instanceof self) {
             $instance = $model;
-        }
-        else {
+        } else {
             $instance = new static($model);
         }
 

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -32,10 +32,7 @@ class Laratables
     public static function recordsOf($model)
     {
         if(!($model instanceof static))
-        {
-            $instance = new static($model);
-            $instance->applyFiltersTo();
-        }
+            $instance = static::forModel($model);
         else $instance = $model;
 
         $records = $instance->fetchRecords();
@@ -61,11 +58,12 @@ class Laratables
      *
      * @param Closure which Accepts and returns Eloquent query
      *
-     * @return void
+     * @return \Freshbitsweb\Laratables\Laratables
      */
     public function modify($closure)
     {
         $this->queryHandler->modify($closure);
+        return $this;
     }
 
     /**

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -27,6 +27,9 @@ class Laratables
     /**
      * Accepts datatables ajax request or Laratables instance and returns table data.
      *
+     * @param Model to query for OR Laratables instance
+     * @param (optional) Closure which Accepts and returns Eloquent query
+     * 
      * @return array Table data
      */
     public static function recordsOf($model, $query = null)

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -41,9 +41,9 @@ class Laratables
         }
 
         $instance->applyFiltersTo();
-        
+
         $records = $instance->fetchRecords();
-        
+
         $records = $instance->recordsTransformer->transformRecords($records);
 
         return $instance->tableData($records);

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -17,7 +17,7 @@ class Laratables
      *
      * @return void
      */
-    protected function __construct($model)
+    public function __construct($model)
     {
         $this->queryHandler = new QueryHandler($model);
         $this->columnManager = new ColumnManager($model);
@@ -29,28 +29,24 @@ class Laratables
      *
      * @return array Table data
      */
-    public static function recordsOf($model)
+    public static function recordsOf($model, $query = null)
     {
-        if(!($model instanceof static))
-            $instance = static::forModel($model);
-        else $instance = $model;
+        if($model instanceof self) {
+            $instance = $model;
+        }
+        else {
+            $instance = new static($model);
+        }
 
+        if($query instanceof \Closure) {
+            $instance->modify($query);
+        }
+
+        $instance->applyFiltersTo();
         $records = $instance->fetchRecords();
         $records = $instance->recordsTransformer->transformRecords($records);
+
         return $instance->tableData($records);
-    }
-
-    /**
-     * Accepts model and returns Laratables instance.
-     *
-     * @return \Freshbitsweb\Laratables\Laratables
-     */
-    public static function forModel($model)
-    {
-        $instance = new static($model);
-        $instance->applyFiltersTo();
-
-        return $instance;
     }
 
     /**
@@ -58,12 +54,11 @@ class Laratables
      *
      * @param Closure which Accepts and returns Eloquent query
      *
-     * @return \Freshbitsweb\Laratables\Laratables
+     * @return void
      */
     public function modify($closure)
     {
         $this->queryHandler->modify($closure);
-        return $this;
     }
 
     /**

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -29,19 +29,19 @@ class Laratables
      *
      * @param Model to query for OR Laratables instance
      * @param (optional) Closure which Accepts and returns Eloquent query
-     * 
+     *
      * @return array Table data
      */
     public static function recordsOf($model, $query = null)
     {
-        if($model instanceof self) {
+        if ($model instanceof self) {
             $instance = $model;
         }
         else {
             $instance = new static($model);
         }
 
-        if($query instanceof \Closure) {
+        if ($query instanceof \Closure) {
             $instance->modify($query);
         }
 

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -25,7 +25,7 @@ class Laratables
     }
 
     /**
-     * Accepts datatables ajax request or Laratables instance and returns table data.
+     * Accepts datatables ajax request and returns table data.
      *
      * @param Model to query for
      * @param (optional) Closure which accepts and returns the Eloquent query builder

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -25,21 +25,47 @@ class Laratables
     }
 
     /**
-     * Accepts datatables ajax request and returns table data.
+     * Accepts datatables ajax request or Laratables instance and returns table data.
      *
      * @return array Table data
      */
     public static function recordsOf($model)
     {
-        $instance = new static($model);
-
-        $instance->applyFiltersTo();
+        if(!($model instanceof static))
+        {
+            $instance = new static($model);
+            $instance->applyFiltersTo();
+        }
+        else $instance = $model;
 
         $records = $instance->fetchRecords();
-
         $records = $instance->recordsTransformer->transformRecords($records);
-
         return $instance->tableData($records);
+    }
+
+    /**
+     * Accepts model and returns Laratables instance.
+     *
+     * @return \Freshbitsweb\Laratables\Laratables
+     */
+    public static function forModel($model)
+    {
+        $instance = new static($model);
+        $instance->applyFiltersTo();
+
+        return $instance;
+    }
+
+    /**
+     * Modify the underlying query of a Laratables instance.
+     *
+     * @param Closure which Accepts and returns Eloquent query
+     *
+     * @return void
+     */
+    public function modify($closure)
+    {
+        $this->queryHandler->modify($closure);
     }
 
     /**

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -27,8 +27,8 @@ class Laratables
     /**
      * Accepts datatables ajax request or Laratables instance and returns table data.
      *
-     * @param Model to query for OR Laratables instance
-     * @param (optional) Closure which Accepts and returns Eloquent query
+     * @param Model to query for or existing Laratables instance
+     * @param (optional) Closure which accepts and returns the Eloquent query builder
      *
      * @return array Table data
      */

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -46,7 +46,7 @@ class Laratables
 
         return $instance->tableData($records);
     }
-    
+
     /**
      * Applies conditions to the query if search is performed in datatables.
      *

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -17,7 +17,7 @@ class Laratables
      *
      * @return void
      */
-    public function __construct($model)
+    protected function __construct($model)
     {
         $this->queryHandler = new QueryHandler($model);
         $this->columnManager = new ColumnManager($model);
@@ -27,21 +27,17 @@ class Laratables
     /**
      * Accepts datatables ajax request or Laratables instance and returns table data.
      *
-     * @param Model to query for or existing Laratables instance
+     * @param Model to query for
      * @param (optional) Closure which accepts and returns the Eloquent query builder
      *
      * @return array Table data
      */
     public static function recordsOf($model, $query = null)
     {
-        if ($model instanceof self) {
-            $instance = $model;
-        } else {
-            $instance = new static($model);
-        }
+        $instance = new static($model);
 
         if ($query instanceof \Closure) {
-            $instance->modify($query);
+            $this->queryHandler->modify($query);
         }
 
         $instance->applyFiltersTo();
@@ -50,19 +46,7 @@ class Laratables
 
         return $instance->tableData($records);
     }
-
-    /**
-     * Modify the underlying query of a Laratables instance.
-     *
-     * @param Closure which Accepts and returns Eloquent query
-     *
-     * @return void
-     */
-    public function modify($closure)
-    {
-        $this->queryHandler->modify($closure);
-    }
-
+    
     /**
      * Applies conditions to the query if search is performed in datatables.
      *

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -17,9 +17,9 @@ class Laratables
      *
      * @return void
      */
-    protected function __construct($model)
+    protected function __construct($model, $query = null)
     {
-        $this->queryHandler = new QueryHandler($model);
+        $this->queryHandler = new QueryHandler($model, $query);
         $this->columnManager = new ColumnManager($model);
         $this->recordsTransformer = new RecordsTransformer($model, $this->columnManager);
     }
@@ -34,11 +34,7 @@ class Laratables
      */
     public static function recordsOf($model, $query = null)
     {
-        $instance = new static($model);
-
-        if ($query instanceof \Closure) {
-            $instance->queryHandler->modify($query);
-        }
+        $instance = new static($model, $query);
 
         $instance->applyFiltersTo();
 

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -37,7 +37,7 @@ class Laratables
         $instance = new static($model);
 
         if ($query instanceof \Closure) {
-            $this->queryHandler->modify($query);
+            $instance->queryHandler->modify($query);
         }
 
         $instance->applyFiltersTo();

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -28,7 +28,7 @@ class Laratables
      * Accepts datatables ajax request and returns table data.
      *
      * @param Model to query for
-     * @param (optional) Closure which accepts and returns the Eloquent query builder
+     * @param (optional) Closure accepts and returns the Eloquent query builder
      *
      * @return array Table data
      */

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -14,13 +14,14 @@ class QueryHandler
      * Initialize properties.
      *
      * @param \Illuminate\Database\Eloquent\Model The model to work on
+     * @param (optional) Closure accepts and returns the Eloquent query builder
      *
      * @return void
      */
     public function __construct($model, $query = null)
     {
         $this->setQuery($model);
-        
+
         if ($query instanceof \Closure) {
             $this->query = $query($this->query);
         }

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -17,9 +17,14 @@ class QueryHandler
      *
      * @return void
      */
-    public function __construct($model)
+    public function __construct($model, $query = null)
     {
         $this->setQuery($model);
+        
+        if ($query instanceof \Closure) {
+            $this->query = $query($this->query);
+        }
+
         $this->recordsCount = $this->filteredCount = $this->query->count();
     }
 
@@ -61,19 +66,6 @@ class QueryHandler
     public function getQuery()
     {
         return $this->query;
-    }
-
-    /**
-     * Modify the underlying query of a Laratables instance.
-     *
-     * @param Closure which Accepts and returns Eloquent query
-     *
-     * @return void
-     */
-    public function modify($closure)
-    {
-        $this->query = $closure($this->query);
-        $this->recordsCount = $this->filteredCount = $this->query->count();
     }
 
     /**

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -64,6 +64,19 @@ class QueryHandler
     }
 
     /**
+     * Modify the underlying query of a Laratables instance.
+     *
+     * @param Closure which Accepts and returns Eloquent query
+     *
+     * @return void
+     */
+    public function modify($closure)
+    {
+        $this->query = $closure($this->query);
+        $this->filteredCount = $this->query->count();
+    }
+
+    /**
      * Returns total records of the table.
      *
      * @return int

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -45,7 +45,7 @@ class QueryHandler
      * @param array Columns to be searched
      * @param string Search value
      *
-     * @return \Illuminate\Database\Query\Builder Query object
+     * @return void
      */
     public function applyFilters($searchColumns, $searchValue)
     {
@@ -56,7 +56,7 @@ class QueryHandler
     /**
      * Returns the query object.
      *
-     * @return int
+     * @return \Illuminate\Database\Query\Builder Query object
      */
     public function getQuery()
     {
@@ -73,7 +73,7 @@ class QueryHandler
     public function modify($closure)
     {
         $this->query = $closure($this->query);
-        $this->filteredCount = $this->query->count();
+        $this->recordsCount = $this->filteredCount = $this->query->count();
     }
 
     /**


### PR DESCRIPTION
My requirement was to have different routes for different tables while still looking at the same model. I wanted to have different tables dependent on the state of the Order, 'Pending', 'In Progress' etc.

With this update, as well as being able to use just like before:

```php
return Laratables::recordsOf(Order::class);
```

We can now also pass a query closure into the `recordsOf` method:

```php
return Laratables::recordsOf(Order::class, function($query)
{
    return $query->where("stage", "=", "Pending");
});
```