### PR TITLE
Fixed 'offset' without 'limit' in sql query

### DIFF
--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -106,12 +106,17 @@ class Laratables
         $orderByValue = $this->columnManager->getOrderBy();
         $orderByStatement = is_array($orderByValue) ? 'orderBy' : 'orderByRaw';
         $orderByValue = Arr::wrap($orderByValue);
-
-        return $query->with($this->columnManager->getRelations())
-            ->offset((int) request('start'))
-            ->limit(min((int) request('length'), 100))
-            ->{$orderByStatement}(...$orderByValue)
-            ->get($this->columnManager->getSelectColumns());
+        $length = (int)request('length');
+        
+        return $length > 0
+            ? $query->with($this->columnManager->getRelations())
+                ->offset((int)request('start'))
+                ->limit(min($length, 100))
+                ->{$orderByStatement}(...$orderByValue)
+                ->get($this->columnManager->getSelectColumns())
+            : $query->with($this->columnManager->getRelations())
+                ->{$orderByStatement}(...$orderByValue)
+                ->get($this->columnManager->getSelectColumns());
     }
 
     /**


### PR DESCRIPTION
When jquery datatables requests for all rows, it sends data with length : -1. When this happens, the offset keyword is included in the generated query without the limit keyword, which throws an error.

sql> select id, isrc, artist, product_title, container_title, label, country, total_plays, revenue, start_at, end_at from records where user_id = 1 order by id asc limit -2 offset 0 [2019-04-11 21:48:13] [42000][1064] You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '-2 offset 0' at line 1

To solve this, if the length is less than 0, we should run the query without the 'limit' and 'offset', since we want to get all rows. I encountered this using mysql/mariadb, I haven't tried with other databases.