### PR TITLE
Allow laratablesRowData in custom class

### DIFF
--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -294,7 +294,7 @@ class ColumnManager
         return $this->selectColumns;
     }
     /** 
-     * Tells us if there is the static laratablesRowData method in the Presenter class
+     * Tells us if there is the static laratablesRowData method in the Presenter class.
      * @return bool
      */
     public function hasRowData() 

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -293,4 +293,11 @@ class ColumnManager
     {
         return $this->selectColumns;
     }
+    /** 
+     * Tells us if there is the static laratablesRowData method in the Presenter class
+     * @return boolean
+     */
+    public function hasRowData() {
+        return method_exists($this->class, 'laratablesRowData');
+    }
 }

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -297,7 +297,8 @@ class ColumnManager
      * Tells us if there is the static laratablesRowData method in the Presenter class
      * @return boolean
      */
-    public function hasRowData() {
+    public function hasRowData() 
+    {
         return method_exists($this->class, 'laratablesRowData');
     }
 }

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -293,8 +293,8 @@ class ColumnManager
     {
         return $this->selectColumns;
     }
-    
-    /** 
+
+    /**
      * Tells us if there is the static laratablesRowData method in the Presenter class.
      * @return bool
      */

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -293,11 +293,12 @@ class ColumnManager
     {
         return $this->selectColumns;
     }
+    
     /** 
      * Tells us if there is the static laratablesRowData method in the Presenter class.
      * @return bool
      */
-    public function hasRowData() 
+    public function hasRowData()
     {
         return method_exists($this->class, 'laratablesRowData');
     }

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -295,7 +295,7 @@ class ColumnManager
     }
     /** 
      * Tells us if there is the static laratablesRowData method in the Presenter class
-     * @return boolean
+     * @return bool
      */
     public function hasRowData() 
     {

--- a/src/RecordsTransformer.php
+++ b/src/RecordsTransformer.php
@@ -171,7 +171,7 @@ class RecordsTransformer
 
         if (method_exists($this->class, 'laratablesRowData')) {
             $datatableParameters['DT_RowData'] = $record->laratablesRowData();
-        } else if ($methodName = $this->columnManager->isCustomColumn($columnName)) {
+        } else if ($methodName = $this->columnManager->hasRowData($columnName)) {
             $datatableParameters['DT_RowData'] = $this->class::laratablesRowData($record);
         }
 

--- a/src/RecordsTransformer.php
+++ b/src/RecordsTransformer.php
@@ -171,6 +171,8 @@ class RecordsTransformer
 
         if (method_exists($this->class, 'laratablesRowData')) {
             $datatableParameters['DT_RowData'] = $record->laratablesRowData();
+        } else if ($methodName = $this->columnManager->isCustomColumn($columnName)) {
+            $datatableParameters['DT_RowData'] = $this->class::laratablesRowData($record);
         }
 
         return $datatableParameters;

--- a/src/RecordsTransformer.php
+++ b/src/RecordsTransformer.php
@@ -171,7 +171,7 @@ class RecordsTransformer
 
         if (method_exists($this->class, 'laratablesRowData')) {
             $datatableParameters['DT_RowData'] = $record->laratablesRowData();
-        } else if ($methodName = $this->columnManager->hasRowData($columnName)) {
+        } elseif ($this->columnManager->hasRowData($columnName)) {
             $datatableParameters['DT_RowData'] = $this->class::laratablesRowData($record);
         }
 


### PR DESCRIPTION
To capsulate all Laratables logic from the model i found a missing link: `laratablesRowData()` in the model.

It was not callable in the custom class like this:

```php
return Laratables::recordsOf(User::class, UserLaratables::class);
```

There was only the `public function` in the `User` class in this example.
`UserLaratables` could not have this function as static with the `User` class as argument.

With this PR, this behaviour changes. You can write a custom `laratablesRowData()` in the `UserLaratables` class like this:

```php
public static function laratablesRowData(User $user) {
    return [
        'foo' => $user->foo,
        'bar' => $user->bar,
    ];
}
```