### PR TITLE
Enable multi-column ordering

### DIFF
--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -198,7 +198,7 @@ class ColumnManager
     /**
      * Returns the name of the column for ordering.
      *
-     * @return string
+     * @return \Illuminate\Support\Collection
      */
     public function getOrderColumns()
     {

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -170,33 +170,9 @@ class ColumnManager
     }
 
     /**
-     * Returns the values for order by clause of the query.
+     * Returns the names of the columns with direction for ordering.
      *
      * @throws IncorrectOrderColumn
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function getOrderBy()
-    {
-        $orderColumns = $this->getOrderColumns();
-
-        $order = request('order');
-
-        return $orderColumns->map(function ($column, $index) use ($order) {
-            if (is_array($column)) {
-                // An order by raw statement
-                return $column[0];
-            }
-
-            return [
-                $column,
-                $order[$index]['dir'],
-            ];
-        });
-    }
-
-    /**
-     * Returns the name of the column for ordering.
      *
      * @return \Illuminate\Support\Collection
      */
@@ -215,16 +191,20 @@ class ColumnManager
                 }
 
                 if ($methodName = $this->hasCustomOrdering($orderColumn)) {
-                    return $this->class::$methodName();
-                }
-
-                if ($methodName = $this->hasCustomRawOrdering($orderColumn)) {
                     return [
-                        $this->class::$methodName($item['dir']),
+                        $this->class::$methodName(),
+                        $item['dir'],
                     ];
                 }
 
-                return $orderColumn;
+                if ($methodName = $this->hasCustomRawOrdering($orderColumn)) {
+                    return $this->class::$methodName($item['dir']);
+                }
+
+                return [
+                    $orderColumn,
+                    $item['dir'],
+                ];
             });
     }
 

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -174,7 +174,7 @@ class ColumnManager
      *
      * @throws IncorrectOrderColumn
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function getOrderBy()
     {
@@ -192,7 +192,7 @@ class ColumnManager
                 $column,
                 $order[$index]['dir'],
             ];
-        })->all();
+        });
     }
 
     /**

--- a/src/ColumnManager.php
+++ b/src/ColumnManager.php
@@ -203,9 +203,9 @@ class ColumnManager
     public function getOrderColumns()
     {
         $requestedColumnNames = $this->getRequestedColumnNames()->toArray();
-        
+
         $order = request('order');
-        
+
         return collect($order)
             ->map(function ($item) use ($requestedColumnNames) {
                 $orderColumn = $requestedColumnNames[$item['column']];

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -103,19 +103,24 @@ class Laratables
     {
         $query = $this->queryHandler->getQuery();
 
-        $orderByValue = $this->columnManager->getOrderBy();
-        $orderByStatement = is_array($orderByValue) ? 'orderBy' : 'orderByRaw';
-        $orderByValue = Arr::wrap($orderByValue);
-
-        return $query->with($this->columnManager->getRelations())
+        $query = $query->with($this->columnManager->getRelations())
             ->when($this->shouldApplyLimit(), function ($query) {
                 $limit = getRecordsLimit((int) request('length'));
 
                 $query->limit($limit)->offset((int) request('start'));
-            })
-            ->{$orderByStatement}(...$orderByValue)
-            ->get($this->columnManager->getSelectColumns())
-        ;
+            });
+
+        $orderByValue = $this->columnManager->getOrderBy();
+
+        foreach ($orderByValue as $order) {
+            if (is_string($order)) {
+                $query = $query->orderByRaw($order);
+            } else {
+                $query = $query->orderBy(...$order);
+            }
+        }
+
+        return $query->get($this->columnManager->getSelectColumns());
     }
 
     /**

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -2,8 +2,6 @@
 
 namespace Freshbitsweb\Laratables;
 
-use Illuminate\Support\Arr;
-
 class Laratables
 {
     /**

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -110,15 +110,15 @@ class Laratables
                 $query->limit($limit)->offset((int) request('start'));
             });
 
-        $orderByValue = $this->columnManager->getOrderBy();
-
-        foreach ($orderByValue as $order) {
-            if (is_string($order)) {
-                $query = $query->orderByRaw($order);
-            } else {
-                $query = $query->orderBy(...$order);
-            }
-        }
+        $this->columnManager
+            ->getOrderBy()
+            ->each(function ($order) use ($query) {
+                if (is_string($order)) {
+                    $query = $query->orderByRaw($order);
+                } else {
+                    $query = $query->orderBy(...$order);
+                }
+            });
 
         return $query->get($this->columnManager->getSelectColumns());
     }

--- a/src/Laratables.php
+++ b/src/Laratables.php
@@ -109,7 +109,7 @@ class Laratables
             });
 
         $this->columnManager
-            ->getOrderBy()
+            ->getOrderColumns()
             ->each(function ($order) use ($query) {
                 if (is_string($order)) {
                     $query = $query->orderByRaw($order);

--- a/tests/OrderingTest.php
+++ b/tests/OrderingTest.php
@@ -93,4 +93,67 @@ class OrderingTest extends TestCase
             ],
         ]);
     }
+
+    /** @test */
+    public function it_orders_the_records_by_multi_column_order()
+    {
+        $user1 = $this->createUsers(
+            $count = 1,
+            $parameters = [
+                'name' => 'B',
+                'email' => 'z@test.com',
+            ]
+        )->first();
+
+        $user2 = $this->createUsers(
+            $count = 1,
+            $parameters = [
+                'name' => 'A',
+                'email' => 'a@test.com',
+            ]
+        )->first();
+
+        $user3 = $this->createUsers(
+            $count = 1,
+            $parameters = [
+                'name' => 'A',
+                'email' => 'b@test.com',
+            ]
+        )->first();
+
+        $order = [
+            [
+                'column' => 1,
+                'dir' => 'asc',
+            ],
+            [
+                'column' => 2,
+                'dir' => 'desc',
+            ],
+        ];
+
+        $response = $this->json(
+            'GET',
+            '/datatables-multi-colunm-order',
+            $this->getDatatablesUrlParameters($searchValue = '', $lengthValue = 10, $order)
+        );
+
+        $response->assertJson([
+            'recordsTotal' => 3,
+            'data' => [
+                [
+                    '0' => $user3->id,
+                    '1' => $user3->name,
+                ],
+                [
+                    '0' => $user2->id,
+                    '1' => $user2->name,
+                ],
+                [
+                    '0' => $user1->id,
+                    '1' => $user1->name,
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Stubs/Controllers/DatatablesController.php
+++ b/tests/Stubs/Controllers/DatatablesController.php
@@ -110,6 +110,16 @@ class DatatablesController
     }
 
     /**
+     * Datatables return with a multi-column order query.
+     *
+     * @return json
+     */
+    public function multiColumnOrder()
+    {
+        return Laratables::recordsOf(User::class);
+    }
+
+    /**
      * Datatables return with an additional column query.
      *
      * @return json

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -52,6 +52,7 @@ abstract class TestCase extends BaseTestCase
                 Route::get('/datatables-custom-search', 'DatatablesController@customSearch');
                 Route::get('/datatables-custom-order', 'DatatablesController@customOrder');
                 Route::get('/datatables-custom-order-raw', 'DatatablesController@customOrderRaw');
+                Route::get('/datatables-multi-colunm-order', 'DatatablesController@multiColumnOrder');
                 Route::get('/datatables-additional-column', 'DatatablesController@additionalColumn');
                 Route::get('/datatables-modify-collection', 'DatatablesController@modifyCollection');
                 Route::get('/datatables-searchable-columns', 'DatatablesController@searchableColumns');

--- a/tests/Traits/PreparesDatatablesUrl.php
+++ b/tests/Traits/PreparesDatatablesUrl.php
@@ -11,7 +11,7 @@ trait PreparesDatatablesUrl
      * @param mixed Length value
      * @return array
      */
-    protected function getDatatablesUrlParameters($searchValue = '', $lengthValue = 10)
+    protected function getDatatablesUrlParameters($searchValue = '', $lengthValue = 10, $order = [])
     {
         $parameters = [
             'draw' => 1,
@@ -24,7 +24,7 @@ trait PreparesDatatablesUrl
 
         $parameters['columns'] = $this->getColumns();
 
-        $parameters['order'] = $this->getOrdering();
+        $parameters['order'] = $order ?: $this->getOrdering();
 
         return $parameters;
     }


### PR DESCRIPTION
DataTables supports multi-column ordering by default.
This pull request enable multi-column ordering support to Laratables.