### PR TITLE
Allow PHP 8.0 support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "freshbitsweb/laratables",
     "description": "Ajax support of DataTables for Laravel 5.5+",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^7.4|^8.0",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
This should resolve issue #99 as there seems to be no big change required to support PHP 8 seeing as PHP 7.3 was already supported.