### PR TITLE
Add Laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,19 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4, 7.3]
+                php: [8.2, 8.1, 8.0]
+                laravel: [9.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
+                include:
+                    -   laravel: 9.*
+                        testbench: 7.*
+                    -   laravel: 10.*
+                        testbench: 8.*
+                exclude:
+                    - laravel: 10.*
+                      php: 8.0
 
-        name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
         steps:
             -   name: Checkout code
@@ -23,10 +32,12 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     coverage: none
+                    tools: composer:v2
 
             -   name: Install dependencies
                 run: |
-                    composer update --prefer-dist --no-interaction --${{ matrix.dependency-version }}
+                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer update --prefer-dist --no-interaction --${{ matrix.dependency-version }} --no-suggest
 
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
+/.idea/
 composer.lock
 .phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2023-06-02
+### Added
+- Support for Laravel 10.x
+- Support for PHP 8.2
+- Drop support EoL PHP and Laravel versions
+
 ## [2.5.0] - 2022-02-16
 ### Added
 - Support for Laravel 9.x

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ There are multiple ways to customize query/data/logic. Check [Customization](#cu
 ## Requirements
 | PHP    | Laravel | Package |
 |--------|---------|---------|
-| 8.1+   | 10.x    | v2.6.0  |
+| 8.0+   | 10.x    | v2.6.0  |
 | 8.0+   | 9.x     | v2.5.0  |
 | 7.3+   | 8.x     | v2.4.0  |
 | 7.2.5+ | 7.x     | v2.3.0  |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The main reason being that our company projects do not use Datatables anymore.
 If you wish to maintain a fork of this package, I would be more than happy to link.
 
 
-# Laratables (Laravel 5.5 to Laravel 9.x)
+# Laratables (Laravel versions according to the [Laravel Support Policy](https://laravel.com/docs/10.x/releases#support-policy))
 A Laravel package to handle server side ajax of [Datatables](https://datatables.net).
 
 ## Table of contents
@@ -87,6 +87,7 @@ There are multiple ways to customize query/data/logic. Check [Customization](#cu
 ## Requirements
 | PHP    | Laravel | Package |
 |--------|---------|---------|
+| 8.1+   | 10.x    | v2.6.0  |
 | 8.0+   | 9.x     | v2.5.0  |
 | 7.3+   | 8.x     | v2.4.0  |
 | 7.2.5+ | 7.x     | v2.3.0  |

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "freshbitsweb/laratables",
-    "description": "Ajax support of DataTables for Laravel 5.5+",
+    "description": "Ajax support of DataTables for Laravel",
     "require": {
-        "php": "^7.3|^7.4|^8.0",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0"
+        "php": "^8.0",
+        "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.23|^7.0.0",
-        "phpunit/phpunit": "^9.3.9",
+        "orchestra/testbench": "^7.9|^8.0",
+        "phpunit/phpunit": "^9.3.9|^10.0",
         "laravel/legacy-factories": "^1.3.0"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Ajax support of DataTables for Laravel",
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.0|^10.0"
+        "illuminate/support": "^9.33.0|^10.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.9|^8.0",


### PR DESCRIPTION
Add Laravel 10 support
Add PHP8.2 support

Arguably should bump to v3 instead of v2.6.0 due to dropping EoL PHP and Laravel versions