### PR TITLE
Support for Laravel 13.x and PHPUnit 12 migration

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
-        laravel: ['9.*', '10.*', '11.*', '12.*']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        laravel: ['9.*', '10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
@@ -24,6 +24,8 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
           - laravel: 10.*
             php: 8.0
@@ -35,6 +37,12 @@ jobs:
             php: 8.1
           - laravel: 12.*
             php: 8.0
+          - laravel: 13.*
+            php: '8.0'
+          - laravel: 13.*
+            php: '8.1'
+          - laravel: 13.*
+            php: '8.2'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-03-21
+### Added
+- Support for Laravel 13.x
+
 ## [5.0.0] - 2025-02-26
 ### Added
 - Support for Laravel 12.x

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ There are multiple ways to customize query/data/logic. Check [Customization](#cu
 ## Requirements
 | PHP    | Laravel | Package |
 |--------|---------|---------|
+| 8.3+   | 13.x    | v6.0.0  |
 | 8.3+   | 12.x    | v5.0.0  |
 | 8.2+   | 11.x    | v4.0.0  |
 | 8.0+   | 10.x    | v3.0.0  |

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "Ajax support of DataTables for Laravel",
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.33.0|^10.0|^11.0|^12.0"
+        "illuminate/support": "^9.33.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.9|^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^9.3.9|^10.0|^11.0",
-        "laravel/legacy-factories": "^1.3.0"
+        "orchestra/testbench": "^7.9|^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^9.3.9|^10.0|^11.0|^12.5.12",
+        "laravel/legacy-factories": "^1.3.0|dev-master"
     },
     "license": "MIT",
     "authors": [

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Str;
 
 class ColumnTest extends TestCase
 {
-    /** @test */
-    public function it_returns_the_custom_column_value()
+    /**
+     * @test
+     */
+    public function test_it_returns_the_custom_column_value()
     {
         $users = $this->createUsers();
 
@@ -24,8 +26,10 @@ class ColumnTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_returns_the_customized_column_value()
+    /**
+     * @test
+     */
+    public function test_it_returns_the_customized_column_value()
     {
         $users = $this->createUsers();
 
@@ -42,8 +46,10 @@ class ColumnTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_loads_additional_columns()
+    /**
+     * @test
+     */
+    public function test_it_loads_additional_columns()
     {
         $users = $this->createUsers();
 
@@ -60,8 +66,10 @@ class ColumnTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_converts_carbon_to_dates()
+    /**
+     * @test
+     */
+    public function test_it_converts_carbon_to_dates()
     {
         $users = $this->createUsers();
 

--- a/tests/DataFetchTest.php
+++ b/tests/DataFetchTest.php
@@ -4,8 +4,10 @@ namespace Freshbitsweb\Laratables\Tests;
 
 class DataFetchTest extends TestCase
 {
-    /** @test */
-    public function it_returns_the_simple_data_as_expected()
+    /**
+     * @test
+     */
+    public function test_it_returns_the_simple_data_as_expected()
     {
         $users = $this->createUsers();
 
@@ -21,8 +23,10 @@ class DataFetchTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_applies_the_closure_condition_with_records_of_call()
+    /**
+     * @test
+     */
+    public function test_it_applies_the_closure_condition_with_records_of_call()
     {
         $users = $this->createUsers(2);
 
@@ -38,8 +42,10 @@ class DataFetchTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_uses_the_separate_class_specified_with_records_of_call()
+    /**
+     * @test
+     */
+    public function test_it_uses_the_separate_class_specified_with_records_of_call()
     {
         $users = $this->createUsers();
 
@@ -56,8 +62,10 @@ class DataFetchTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_applies_the_custom_query_conditions()
+    /**
+     * @test
+     */
+    public function test_it_applies_the_custom_query_conditions()
     {
         $users = $this->createUsers(2);
 
@@ -73,8 +81,10 @@ class DataFetchTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_works_on_the_collection_after_fetching_data()
+    /**
+     * @test
+     */
+    public function test_it_works_on_the_collection_after_fetching_data()
     {
         $users = $this->createUsers();
 

--- a/tests/DataTableAttributesTest.php
+++ b/tests/DataTableAttributesTest.php
@@ -4,8 +4,10 @@ namespace Freshbitsweb\Laratables\Tests;
 
 class DataTableAttributesTest extends TestCase
 {
-    /** @test */
-    public function it_returns_the_simple_data_as_expected()
+    /**
+     * @test
+     */
+    public function test_it_returns_the_simple_data_as_expected()
     {
         $users = $this->createUsers();
 

--- a/tests/OrderingTest.php
+++ b/tests/OrderingTest.php
@@ -4,8 +4,10 @@ namespace Freshbitsweb\Laratables\Tests;
 
 class OrderingTest extends TestCase
 {
-    /** @test */
-    public function it_orders_the_records_as_expected()
+    /**
+     * @test
+     */
+    public function test_it_orders_the_records_as_expected()
     {
         $user1 = $this->createUsers(
             $count = 1,
@@ -42,8 +44,10 @@ class OrderingTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_orders_the_records_as_per_custom_ordering()
+    /**
+     * @test
+     */
+    public function test_it_orders_the_records_as_per_custom_ordering()
     {
         $user1 = $this->createUsers(
             $count = 1,
@@ -92,8 +96,10 @@ class OrderingTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_orders_the_records_with_order_by_raw()
+    /**
+     * @test
+     */
+    public function test_it_orders_the_records_with_order_by_raw()
     {
         $user1 = $this->createUsers(
             $count = 1,
@@ -144,8 +150,10 @@ class OrderingTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_orders_the_records_by_multi_column_order()
+    /**
+     * @test
+     */
+    public function test_it_orders_the_records_by_multi_column_order()
     {
         $user1 = $this->createUsers(
             $count = 1,

--- a/tests/RecordsLimitTest.php
+++ b/tests/RecordsLimitTest.php
@@ -4,8 +4,10 @@ namespace Freshbitsweb\Laratables\Tests;
 
 class RecordsLimitTest extends TestCase
 {
-    /** @test */
-    public function it_can_limit_records_to_maximum_as_per_the_configuration()
+    /**
+     * @test
+     */
+    public function test_it_can_limit_records_to_maximum_as_per_the_configuration()
     {
         $users = $this->createUsers(2);
 
@@ -18,8 +20,10 @@ class RecordsLimitTest extends TestCase
         $response->assertJsonCount(1, 'data');
     }
 
-    /** @test */
-    public function it_can_allow_unlimited_records_as_per_the_configuration()
+    /**
+     * @test
+     */
+    public function test_it_can_allow_unlimited_records_as_per_the_configuration()
     {
         $users = $this->createUsers(50);
 
@@ -32,8 +36,10 @@ class RecordsLimitTest extends TestCase
         $response->assertJsonCount(50, 'data');
     }
 
-    /** @test */
-    public function it_can_limit_records_based_on_the_request_even_when_unlimited_records_are_allowed()
+    /**
+     * @test
+     */
+    public function test_it_can_limit_records_based_on_the_request_even_when_unlimited_records_are_allowed()
     {
         $users = $this->createUsers(50);
 
@@ -46,8 +52,10 @@ class RecordsLimitTest extends TestCase
         $response->assertJsonCount(20, 'data');
     }
 
-    /** @test */
-    public function it_prioritizes_request_limit_compared_to_configuration_limit()
+    /**
+     * @test
+     */
+    public function test_it_prioritizes_request_limit_compared_to_configuration_limit()
     {
         $users = $this->createUsers(50);
 

--- a/tests/RelationshipTest.php
+++ b/tests/RelationshipTest.php
@@ -4,8 +4,10 @@ namespace Freshbitsweb\Laratables\Tests;
 
 class RelationshipTest extends TestCase
 {
-    /** @test */
-    public function it_returns_the_relationship_column_value()
+    /**
+     * @test
+     */
+    public function test_it_returns_the_relationship_column_value()
     {
         $users = $this->createUsers();
 
@@ -23,8 +25,10 @@ class RelationshipTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_uses_the_custom_relationship_query()
+    /**
+     * @test
+     */
+    public function test_it_uses_the_custom_relationship_query()
     {
         $users = $this->createUsers();
 

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Str;
 
 class SearchTest extends TestCase
 {
-    /** @test */
-    public function it_applies_the_search_as_per_the_custom_method()
+    /**
+     * @test
+     */
+    public function test_it_applies_the_search_as_per_the_custom_method()
     {
         $randomString = Str::random(20);
 
@@ -36,8 +38,10 @@ class SearchTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_applies_the_search_to_searchable_columns()
+    /**
+     * @test
+     */
+    public function test_it_applies_the_search_to_searchable_columns()
     {
         $randomString = Str::random(20);
 
@@ -65,8 +69,10 @@ class SearchTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_skips_non_searchable_columns_during_the_search()
+    /**
+     * @test
+     */
+    public function test_it_skips_non_searchable_columns_during_the_search()
     {
         $users = $this->createUsers();
 


### PR DESCRIPTION
I have updated the package to support Laravel 13.x and newer versions of PHP (8.3, 8.4, 8.5). This involved updating the GitHub Actions workflow, composer.json dependencies, and documentation. I also migrated the test suite to be compatible with PHPUnit 12 by ensuring all test methods have the 'test_' prefix. All tests passed after the upgrade.

---
*PR created automatically by Jules for task [7880973649231374818](https://jules.google.com/task/7880973649231374818) started by @gauravmak*